### PR TITLE
Build instructions: Update build instructions

### DIFF
--- a/README
+++ b/README
@@ -32,6 +32,9 @@ required as well.  Use good judgment.
 How to "compile" the check_hpasm script.
 --------------------------------------------------------
 
+0) If you obtained the source core from version control (not a release archive):
+   Execute 'autoreconf' (-v) which will generate the configure scripts.
+
 1) Run the configure script to initialize variables and create a Makefile, etc.
 
 	./configure --prefix=BASEDIRECTORY --with-nagios-user=SOMEUSER --with-nagios-group=SOMEGROUP --with-perl=PATH_TO_PERL --with-noinst-level=LEVEL --with-degrees=UNIT --with-perfdata --with-hpacucli


### PR DESCRIPTION
- Regenerate aclocal.m4 with aclocal to make automake 1.15 happy.
- Rename configure.in (deprecated) into .ac to make autoconf happy
  I didn't find where exactly they started to consider it deprecated.