### PR TITLE
Add ssacli as an alias to hpssacli in new naming scheme

### DIFF
--- a/plugins-scripts/HP/Proliant.pm
+++ b/plugins-scripts/HP/Proliant.pm
@@ -341,19 +341,16 @@ EOEO
           if ($self->{runtime}->{options}->{hpacucli}) {
             #1 oder 0. pfad selber finden
             my $hpacucli = undef;
-            if (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } elsif (-e '/usr/sbin/hpacucli') {
-              $hpacucli = '/usr/sbin/hpacucli';
-            } elsif (-e '/usr/local/sbin/hpacucli') {
-              $hpacucli = '/usr/local/sbin/hpacucli';
-            } elsif (-e '/usr/sbin/hpssacli') {
-              $hpacucli = '/usr/sbin/hpssacli';
-            } elsif (-e '/usr/local/sbin/hpssacli') {
-              $hpacucli = '/usr/local/sbin/hpssacli';
-            } else {
+            CLIEXECTEST:
+            foreach my $cliexec (qw(ssacli hpssacli hpacucli)) {
+              foreach my $clipaths (qw(/usr/sbin/ /usr/local/sbin/ /sbin/)) {
+                if (-e $clipaths . $cliexec) {
+                  $hpacucli = $clipaths . $cliexec;
+                  last CLIEXECTEST;
+                }
+              }
+            }
+            if (! defined $hpacucli) {
               $hpacucli = $hpasmcli;
               $hpacucli =~ s/^sudo\s*//;
               $hpacucli =~ s/hpasmcli/hpacucli/;


### PR DESCRIPTION
HPE is moving away from hpacucli in modern Linux distributions and has renamed its successor into ssacli.

I'd really like to "steal" that patch from Frederic Johansson before we run into updated systems where hpacucli is either missing or not supported anymore.

The patch was cherry-picked from an upstream pull request, and the commit message contains a reference to the pull request, as well as the tree I've "stolen" the patch from:

I've compiled the new version and compared with a system that had hpacucli and ssacli present, moved hpacucli away and could confirm that check_hpasm still worked.